### PR TITLE
Force invariant culture for number parsing

### DIFF
--- a/Source.Common/Platform.cs
+++ b/Source.Common/Platform.cs
@@ -1,6 +1,7 @@
 using Source.Common;
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -48,6 +49,13 @@ public static class Platform
 	}
 
 	public static void Initialize() {
+		// Source's data files (KeyValues, .res, .vmt, convar values) are always en-US formatted, so the
+		// process must not follow the user's locale - float.Parse("0.25") throws under fr-FR otherwise.
+		CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+		CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+		Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+		Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
 		ThreadUtils.SetMainThread();
 	}
 }

--- a/Source.GUI.Controls/PropertySheet.cs
+++ b/Source.GUI.Controls/PropertySheet.cs
@@ -2,6 +2,8 @@
 using Source.Common.GUI;
 using Source.Common.Input;
 
+using System.Globalization;
+
 namespace Source.GUI.Controls;
 
 class ContextLabel : Label
@@ -534,7 +536,7 @@ public class PropertySheet : EditablePanel
 			Border = scheme.GetBorder("RaisedBorder")!;
 
 		SetBorder(Border);
-		PageTransitionEffectTime = float.Parse(scheme.GetResourceString("PropertySheet.TransitionEffectTime"));
+		PageTransitionEffectTime = float.TryParse(scheme.GetResourceString("PropertySheet.TransitionEffectTime"), NumberStyles.Float, CultureInfo.InvariantCulture, out float transitionTime) ? transitionTime : 0;
 		TabFont = scheme.GetFont(SmallTabs ? "DefaultVerySmall" : "DefaultSmall")!;
 
 		if (TabKV != null)


### PR DESCRIPTION
On locales where `.` is not the decimal separator (fr-FR, de-DE, ...), `float.Parse` on game data throws `FormatException` — opening any main menu dialog crashes in `PropertySheet.ApplySchemeSettings` parsing `PropertySheet.TransitionEffectTime` ("0.25"). Both `OptionsDialog` (via `PropertyDialog`) and `ServerBrowserDialog` hit it on construction.

`Platform.Initialize` now pins the process to `InvariantCulture`. It is the first call in both the Launcher and Dedicated entry points, so it covers every parse site — not just this one. The `TryParse` sites did not throw but silently yielded 0, e.g. `ConVar.cs:222` turned any fractional convar value into 0.

Also made the PropertySheet parse explicit and non-throwing, matching the existing style in `BasePanel` — `ClientScheme.res` defines no `PropertySheet` keys, so a missing value would otherwise throw on the empty string.